### PR TITLE
Table Name must allow special characters

### DIFF
--- a/lib/common/util/validate.js
+++ b/lib/common/util/validate.js
@@ -338,7 +338,7 @@ exports.tableNameIsValid = function (table, callback) {
     return fail(new RangeError('Table name cannot be \'Tables\'.'));
   }
 
-  if (table.match(/^([A-Za-z][A-Za-z0-9]{2,62})$/) !== null || table === '$MetricsCapacityBlob' || table.match(/^(\$Metrics(HourPrimary|MinutePrimary|HourSecondary|MinuteSecondary)?(Transactions)(Blob|Queue|Table|File))$/) !== null)
+  if (table === '$MetricsCapacityBlob' || table.match(/^(\$Metrics(HourPrimary|MinutePrimary|HourSecondary|MinuteSecondary)?(Transactions)(Blob|Queue|Table|File))$/) !== null)
   {
     callback();
     return true;


### PR DESCRIPTION
There is only empty string validation check in other TableAPI types(java/python etc) for cosmosdb. So in NodeJS TableAPI type there is no need of Regex check for table name validation, as it is not required. I am keeping other validation check as it is.